### PR TITLE
Initialize Next.js scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Crewlink
+
+This project is a lightweight starter for a film and TV crew networking app built with Next.js and TypeScript. It demonstrates Firebase authentication, Firestore storage, and Tailwind CSS styling.
+
+## Folder Structure
+
+```
+lib/            Firebase configuration
+pages/          Next.js route pages
+components/     Reusable UI components
+styles/         Global styles (Tailwind)
+public/         Static assets like the logo
+```
+
+## Development
+
+1. Install dependencies with `npm install`.
+2. Run the development server with `npm run dev`.
+
+A minimal set of configuration files is provided for Next.js, TypeScript, and Tailwind CSS. Authentication and Firestore logic live in `lib/firebase.ts`.
+
+## Architecture Notes
+
+Pages under `pages/` map directly to application routes. Components in `components/` encapsulate UI pieces like the navigation bar, user profile cards, project forms, and an authentication guard. Firebase is initialized once in `lib/firebase.ts` to share the configuration across the app.

--- a/components/AuthGuard.tsx
+++ b/components/AuthGuard.tsx
@@ -1,0 +1,17 @@
+import { useRouter } from 'next/router';
+import { useEffect, ReactNode } from 'react';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '../lib/firebase';
+
+export default function AuthGuard({ children }: { children: ReactNode }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (user) => {
+      if (!user) router.push('/login');
+    });
+    return () => unsub();
+  }, [router]);
+
+  return <>{children}</>;
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link';
+
+export default function Navbar() {
+  return (
+    <nav className="p-4 bg-gray-800 text-white flex space-x-4">
+      <Link href="/" className="font-semibold">Home</Link>
+      <Link href="/dashboard">Dashboard</Link>
+      <Link href="/projects/new">New Project</Link>
+    </nav>
+  );
+}

--- a/components/ProjectForm.tsx
+++ b/components/ProjectForm.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+export default function ProjectForm() {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // TODO: save to Firestore
+    console.log('submit', { title, description });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input
+        className="border p-2 w-full"
+        placeholder="Project Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <textarea
+        className="border p-2 w-full"
+        placeholder="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+        Save Project
+      </button>
+    </form>
+  );
+}

--- a/components/UserCard.tsx
+++ b/components/UserCard.tsx
@@ -1,0 +1,22 @@
+interface Props {
+  name: string;
+  skills: string[];
+  avatarUrl?: string;
+}
+
+export default function UserCard({ name, skills, avatarUrl }: Props) {
+  return (
+    <div className="border p-4 rounded flex items-center space-x-4">
+      {avatarUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={avatarUrl} alt={name} className="w-12 h-12 rounded-full" />
+      ) : (
+        <div className="w-12 h-12 bg-gray-300 rounded-full" />
+      )}
+      <div>
+        <p className="font-semibold">{name}</p>
+        <p className="text-sm text-gray-500">{skills.join(', ')}</p>
+      </div>
+    </div>
+  );
+}

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,0 +1,18 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+export const storage = getStorage(app);

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "crewlink",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "firebase": "^9.6.11",
+    "next": "13.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.7",
+    "postcss": "^8.4.14",
+    "tailwindcss": "^3.1.8",
+    "typescript": "^4.8.4"
+  }
+}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '../lib/firebase';
+import Navbar from '../components/Navbar';
+
+export default function Dashboard() {
+  const router = useRouter();
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (user) => {
+      if (!user) router.push('/login');
+    });
+    return () => unsub();
+  }, [router]);
+
+  return (
+    <div>
+      <Navbar />
+      <main className="p-8">
+        <h1 className="text-xl font-bold">Dashboard</h1>
+      </main>
+    </div>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,17 @@
+import type { NextPage } from 'next';
+import Head from 'next/head';
+import Link from 'next/link';
+
+const Home: NextPage = () => (
+  <div className="min-h-screen p-8">
+    <Head>
+      <title>Crewlink</title>
+    </Head>
+    <h1 className="text-2xl font-bold mb-4">Welcome to Crewlink</h1>
+    <Link href="/signup" className="text-blue-500 underline">
+      Get Started
+    </Link>
+  </div>
+);
+
+export default Home;

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '../lib/firebase';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+      router.push('/dashboard');
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">Log In</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="email"
+          placeholder="Email"
+          className="border p-2 w-full"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="border p-2 w-full"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <p className="text-red-500">{error}</p>}
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+          Log In
+        </button>
+      </form>
+      <p className="mt-4">
+        Don&apos;t have an account?{' '}
+        <Link href="/signup" className="text-blue-500 underline">
+          Sign up
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router';
+import Navbar from '../../components/Navbar';
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  return (
+    <div>
+      <Navbar />
+      <main className="p-8">
+        <h1 className="text-xl font-bold">Profile {id}</h1>
+      </main>
+    </div>
+  );
+}

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router';
+import Navbar from '../../components/Navbar';
+
+export default function ProjectPage() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  return (
+    <div>
+      <Navbar />
+      <main className="p-8">
+        <h1 className="text-xl font-bold">Project {id}</h1>
+      </main>
+    </div>
+  );
+}

--- a/pages/projects/new.tsx
+++ b/pages/projects/new.tsx
@@ -1,0 +1,14 @@
+import ProjectForm from '../../components/ProjectForm';
+import Navbar from '../../components/Navbar';
+
+export default function NewProject() {
+  return (
+    <div>
+      <Navbar />
+      <main className="p-8">
+        <h1 className="text-xl font-bold mb-4">New Project</h1>
+        <ProjectForm />
+      </main>
+    </div>
+  );
+}

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+import { doc, setDoc } from 'firebase/firestore';
+import { auth, db } from '../lib/firebase';
+import Link from 'next/link';
+
+export default function Signup() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const cred = await createUserWithEmailAndPassword(auth, email, password);
+      await setDoc(doc(db, 'users', cred.user.uid), {
+        uid: cred.user.uid,
+        email: cred.user.email,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">Sign Up</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="email"
+          placeholder="Email"
+          className="border p-2 w-full"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="border p-2 w-full"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-blue-500 text-white px-4 py-2"
+          disabled={loading}
+        >
+          Sign Up
+        </button>
+      </form>
+      <p className="mt-4">
+        Already have an account?{' '}
+        <Link href="/login" className="text-blue-500 underline">
+          Log in
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
+  <text x="0" y="15" font-size="15">Crewlink</text>
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create starter Next.js project with TypeScript
- add Firebase config and sample components
- set up pages for auth, dashboard, profile and projects
- include Tailwind setup and basic global styles
- add README with project overview

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68685b4a639c832c851764f554b7c8e6